### PR TITLE
HOT-FIX: fix order price calculations

### DIFF
--- a/app/controllers/order.py
+++ b/app/controllers/order.py
@@ -12,7 +12,7 @@ class OrderController(BaseController):
 
     @staticmethod
     def calculate_order_price(size_price: float, ingredients: list):
-        price = sum(ingredient.price for ingredient in ingredients)
+        price = sum(ingredient.price for ingredient in ingredients)+size_price
         return round(price, 2)
 
     @classmethod


### PR DESCRIPTION
This PR fixes the order price calculation issue. The issue was that the size price was not added to the total price. In this PR, I added the size price to the order price calculation function, which now correctly calculates the total order price based on the size and toppings selected by the user.

Changes Made:

    Added size_price to the calculateOrderPrice function.
    Updated the calculateOrderPrice function to correctly calculate the total order price based on the size and toppings selected by the user.

Tests:

    comprove test cases to test the calculateOrderPrice function with different size and topping combinations to ensure that the function is correctly calculating the total order price.


